### PR TITLE
remove use deprecated AM_PATH_XML2 aclocal macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AM_INIT_AUTOMAKE()
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CONFIG_MACRO_DIR([m4])
+PKG_PROG_PKG_CONFIG
 
 # Special host-dependent stuff
 case ${host} in
@@ -92,10 +93,10 @@ if test "x$with_libexpat" = "xyes"; then
 fi
 
 if test "x$with_libxml2" = "xyes" && test "x$have_libexpat" != "xyes"; then
-   AM_PATH_XML2([2.6.24], [have_libxml2=yes])
-   if test "x$have_libxml2" = "xyes"; then
+   PKG_CHECK_MODULES([XML], [libxml-2.0 >= 2.6.24], [
       AC_DEFINE([HAVE_LIBXML2], [1], [Define to 1 if you have libxml2.])
-   fi
+      have_libxml2=yes
+   ])
 fi
 
 if test "x$have_libexpat" != "xyes" && test "x$have_libxml2" != "xyes"; then

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -2,8 +2,8 @@ SUBDIRS = includes
 
 AM_CPPFLAGS = -I$(srcdir)/includes -I$(builddir)/includes \
 	$(WARNCFLAGS) $(ADDCFLAGS) \
-	@XML_CPPFLAGS@ @EXPAT_CFLAGS@ \
-	@DEFS@
+	$(XML_CFLAGS) \
+	$(EXPAT_CFLAGS)
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libmetalink.pc
@@ -60,4 +60,5 @@ endif
 libmetalink_la_SOURCES = $(HFILES) $(OBJECTS)
 libmetalink_la_LDFLAGS = -no-undefined \
         -version-info $(LT_CURRENT):$(LT_REVISION):$(LT_AGE) \
-	@XML_LIBS@ @EXPAT_LIBS@
+	$(XML_LIBS) \
+	$(EXPAT_LIBS)


### PR DESCRIPTION
Remove use deprecated AM_PATH_XML2 and use PKG_CHECK_MODULES and PKG_PROG_PKG_CONFIG aclocal macros.